### PR TITLE
add additional data to soap endpoint list recurring details response

### DIFF
--- a/lib/adyen/api/recurring_service.rb
+++ b/lib/adyen/api/recurring_service.rb
@@ -167,18 +167,16 @@ module Adyen
         end
 
         def parse_additional_data(xpath)
-          if xpath.empty?
-            {}
-          else
-            results = {}
-            xpath.map do |node|
-              key = node.text('./recurring:entry/recurring:key')
-              value = node.text('./recurring:entry/recurring:value')
-              results[key] = value unless key.empty?
-            end
+          return {} if xpath.empty?
 
-            results
+          results = {}
+          xpath.map do |node|
+            key = node.text('./recurring:entry/recurring:key')
+            value = node.text('./recurring:entry/recurring:value')
+            results[key] = value unless key.empty?
           end
+
+          results
         end
       end
 

--- a/test/unit/api/recurring_service_test.rb
+++ b/test/unit/api/recurring_service_test.rb
@@ -71,6 +71,7 @@ describe Adyen::API::RecurringService do
             :number => '1111'
           },
           :recurring_detail_reference => 'RecurringDetailReference1',
+          :additional_data => { "newAlias" => "123456" },
           :variant => 'mc',
           :creation_date => DateTime.parse('2009-10-27T11:50:12.178+01:00')
         },
@@ -85,6 +86,7 @@ describe Adyen::API::RecurringService do
             :holder_name => 'S. Hopper'
           },
           :recurring_detail_reference => 'RecurringDetailReference2',
+          :additional_data => { "newAlias" => "123456" },
           :variant => 'IDEAL',
           :creation_date => DateTime.parse('2009-10-27T11:26:22.216+01:00')
         },
@@ -97,6 +99,7 @@ describe Adyen::API::RecurringService do
             :bank_name        => 'TestBank',
           },
           :recurring_detail_reference => 'RecurringDetailReference3',
+          :additional_data => { "newAlias" => "123456" },
           :variant => 'elv',
           :creation_date => DateTime.parse('2009-10-27T11:26:22.216+01:00')
         }

--- a/test/unit/api/test_helper.rb
+++ b/test/unit/api/test_helper.rb
@@ -328,6 +328,12 @@ LIST_RESPONSE = <<EOS
             <elv xsi:nil="true"/>
             <name/>
             <recurringDetailReference>RecurringDetailReference1</recurringDetailReference>
+            <additionalData>
+              <entry>
+                <key xsi:type="xsd:string">newAlias</key>
+                <value xsi:type="xsd:string">123456</value>
+              </entry>
+            </additionalData>
             <variant>mc</variant>
           </RecurringDetail>
           <RecurringDetail>
@@ -345,6 +351,12 @@ LIST_RESPONSE = <<EOS
             <elv xsi:nil="true"/>
             <name/>
             <recurringDetailReference>RecurringDetailReference2</recurringDetailReference>
+            <additionalData>
+              <entry>
+                <key xsi:type="xsd:string">newAlias</key>
+                <value xsi:type="xsd:string">123456</value>
+              </entry>
+            </additionalData>
             <variant>IDEAL</variant>
           </RecurringDetail>
           <RecurringDetail>
@@ -360,6 +372,12 @@ LIST_RESPONSE = <<EOS
             <creationDate>2009-10-27T11:26:22.216+01:00</creationDate>
             <name/>
             <recurringDetailReference>RecurringDetailReference3</recurringDetailReference>
+            <additionalData>
+              <entry>
+                <key xsi:type="xsd:string">newAlias</key>
+                <value xsi:type="xsd:string">123456</value>
+              </entry>
+            </additionalData>
             <variant>elv</variant>
           </RecurringDetail>
         </details>


### PR DESCRIPTION
@panthomakos @stravacd this is the PR I plan to open against https://github.com/wvanbergen/adyen. I wanted to get your quick feedback before I open that external PR.

Note, that I took the implementation of `parse_additional_data` from https://github.com/wvanbergen/adyen/blob/master/lib/adyen/api/payment_service.rb#L343